### PR TITLE
remove the arg `gpu_id` in the function `set_params`

### DIFF
--- a/parl/framework/agent_base.py
+++ b/parl/framework/agent_base.py
@@ -104,4 +104,4 @@ class Agent(object):
         Args:
             params: List of numpy array.
         """
-        self.alg.set_params(params, gpu_id=self.gpu_id)
+        self.alg.set_params(params)

--- a/parl/framework/algorithm_base.py
+++ b/parl/framework/algorithm_base.py
@@ -61,11 +61,11 @@ class Algorithm(object):
         """
         return self.model.get_params()
 
-    def set_params(self, params, gpu_id):
+    def set_params(self, params):
         """ Set parameters of self.model
 
         Args:
             params: List of numpy array.
             gpu_id: gpu id where self.model in. (if gpu_id < 0, means in cpu.)
         """
-        self.model.set_params(params, gpu_id=gpu_id)
+        self.model.set_params(params)

--- a/parl/framework/model_base.py
+++ b/parl/framework/model_base.py
@@ -132,7 +132,7 @@ class Network(object):
 
         return params
 
-    def set_params(self, params, gpu_id):
+    def set_params(self, params):
         """ Set parameters in this Network with params
         
         Args:
@@ -142,7 +142,7 @@ class Network(object):
         assert len(params) == len(self.parameter_names), \
                 'size of input params should be same as parameters number of current Network'
         for (param_name, param) in list(zip(self.parameter_names, params)):
-            set_value(param_name, param, gpu_id)
+            set_value(param_name, param)
 
     def _get_parameter_names(self, obj):
         """ Recursively get parameter names in obj,

--- a/parl/framework/tests/model_base_test.py
+++ b/parl/framework/tests/model_base_test.py
@@ -575,7 +575,7 @@ class ModelBaseTest(unittest.TestCase):
         params = self.model.get_params()
         new_params = [x + 1.0 for x in params]
 
-        self.model.set_params(new_params, self.gpu_id)
+        self.model.set_params(new_params)
 
         for x, y in list(zip(new_params, self.model.get_params())):
             self.assertEqual(np.sum(x), np.sum(y))
@@ -604,7 +604,7 @@ class ModelBaseTest(unittest.TestCase):
 
         # pass parameters of self.model to model2
         params = model1.get_params()
-        model2.set_params(params, self.gpu_id)
+        model2.set_params(params)
 
         random_obs = np.random.random(size=(N, 4)).astype('float32')
         for i in range(N):
@@ -626,7 +626,7 @@ class ModelBaseTest(unittest.TestCase):
         params = self.model.get_params()
 
         try:
-            self.model.set_params(params[1:], self.gpu_id)
+            self.model.set_params(params[1:])
         except:
             # expected
             return
@@ -645,7 +645,7 @@ class ModelBaseTest(unittest.TestCase):
 
         params.reverse()
 
-        self.model.set_params(params, self.gpu_id)
+        self.model.set_params(params)
 
         x = np.random.random(size=(1, 4)).astype('float32')
 

--- a/parl/plutils/common.py
+++ b/parl/plutils/common.py
@@ -17,6 +17,7 @@ Common functions of PARL framework
 
 import paddle.fluid as fluid
 from paddle.fluid.executor import _fetch_var
+from parl.utils import get_gpu_count
 
 __all__ = ['fetch_framework_var', 'fetch_value', 'set_value', 'inverse']
 
@@ -52,7 +53,7 @@ def fetch_value(attr_name):
     return _fetch_var(attr_name, return_numpy=True)
 
 
-def set_value(attr_name, value, gpu_id):
+def set_value(attr_name, value):
     """ Given name of ParamAttr, set numpy value to the parameter in global_scope
     
     Args:
@@ -60,6 +61,7 @@ def set_value(attr_name, value, gpu_id):
         value: numpy array
         gpu_id: gpu id where the parameter in
     """
+    gpu_id = 0 if get_gpu_count() > 0 else -1
     place = fluid.CPUPlace() if gpu_id < 0 \
             else fluid.CUDAPlace(gpu_id)
     var = _fetch_var(attr_name, return_numpy=False)


### PR DESCRIPTION
Users are not expected to specify the place where params are placed(CPU or GPU).
In our framework , we encourage users to specify the GPU to use by setting the environment variable like `export CUDA_VISIBLE_DEVICES="0"`, or to use the CPU to store parameters by `export CUDA_VISIBLE_DEVICES=""`