### PR TITLE
fix some problems of tensorboard

### DIFF
--- a/examples/A2C/atari_model.py
+++ b/examples/A2C/atari_model.py
@@ -14,7 +14,6 @@
 
 import parl
 import paddle.fluid as fluid
-from paddle.fluid.param_attr import ParamAttr
 from parl import layers
 
 

--- a/parl/utils/logger.py
+++ b/parl/utils/logger.py
@@ -18,6 +18,7 @@ import os
 import os.path
 import sys
 from termcolor import colored
+import shutil
 
 __all__ = ['set_dir', 'get_dir', 'set_level']
 
@@ -140,5 +141,6 @@ mod = sys.modules['__main__']
 if hasattr(mod, '__file__'):
     basename = os.path.basename(mod.__file__)
     auto_dirname = os.path.join('log_dir', basename[:basename.rfind('.')])
+    shutil.rmtree(auto_dirname, ignore_errors=True)
     set_dir(auto_dirname)
     _logger.info("Argv: " + ' '.join(sys.argv))

--- a/parl/utils/tensorboard.py
+++ b/parl/utils/tensorboard.py
@@ -20,6 +20,7 @@ __all__ = []
 _writer = None
 _WRITTER_METHOD = ['add_scalar', 'add_histogram', 'close', 'flush']
 
+
 def create_file_after_first_call(func_name):
     def call(*args, **kwargs):
         global _writer
@@ -28,6 +29,7 @@ def create_file_after_first_call(func_name):
         func = getattr(_writer, func_name)
         func(*args, **kwargs)
         _writer.flush()
+
     return call
 
 

--- a/parl/utils/tensorboard.py
+++ b/parl/utils/tensorboard.py
@@ -17,10 +17,21 @@ from parl.utils import logger
 
 __all__ = []
 
-_writer = SummaryWriter(logdir=logger.get_dir())
+_writer = None
 _WRITTER_METHOD = ['add_scalar', 'add_histogram', 'close', 'flush']
 
+def create_file_after_first_call(func_name):
+    def call(*args, **kwargs):
+        global _writer
+        if _writer is None:
+            _writer = SummaryWriter(logdir=logger.get_dir())
+        func = getattr(_writer, func_name)
+        func(*args, **kwargs)
+        _writer.flush()
+    return call
+
+
 # export writter functions
-for func in _WRITTER_METHOD:
-    locals()[func] = getattr(_writer, func)
-    __all__.append(func)
+for func_name in _WRITTER_METHOD:
+    locals()[func_name] = create_file_after_first_call(func_name)
+    __all__.append(func_name)


### PR DESCRIPTION
### This PR:
1. deletes previous files relative to tensorboard to avoid potential chaos in tensorboard files.
2. creates tensorboard files after the first call of tensorboard functions. We used to create a writer when importing parl.utils.tensorboard.

When users run the following code: 
```python
from parl.utils import logger
from parl.utils import tensorboard
import numpy as np
```
parl will not create any tensorbard files.