### PR TITLE
fix issue#101

### DIFF
--- a/parl/utils/machine_info.py
+++ b/parl/utils/machine_info.py
@@ -16,7 +16,7 @@ import os
 import platform
 import subprocess
 from parl.utils import logger
-from parl.utils import utils 
+from parl.utils import utils
 
 __all__ = ['get_gpu_count', 'get_ip_address', 'is_gpu_available']
 
@@ -101,5 +101,6 @@ def is_gpu_available():
         from paddle import fluid
         if ret is True and not fluid.is_compiled_with_cuda():
             logger.warn("Found non-empty CUDA_VISIBLE_DEVICES. \
-                But PARL found that Paddle was not complied with CUDA, which may cause issues.")
+                But PARL found that Paddle was not complied with CUDA, which may cause issues."
+                        )
     return ret

--- a/parl/utils/machine_info.py
+++ b/parl/utils/machine_info.py
@@ -16,6 +16,7 @@ import os
 import platform
 import subprocess
 from parl.utils import logger
+from parl.utils import utils 
 
 __all__ = ['get_gpu_count', 'get_ip_address', 'is_gpu_available']
 
@@ -95,4 +96,10 @@ def is_gpu_available():
     Returns:
       True if a gpu device can be found.
     """
-    return get_gpu_count() > 0
+    ret = get_gpu_count() > 0
+    if utils._HAS_FLUID:
+        from paddle import fluid
+        if ret is True and not fluid.is_compiled_with_cuda():
+            logger.warn("Found non-empty CUDA_VISIBLE_DEVICES. \
+                But PARL found that Paddle was not complied with CUDA, which may cause issues.")
+    return ret


### PR DESCRIPTION
```python
export CUDA_VISIBLE_DEVICES="0"
>> from parl.utils import machine_info
>> machine_info.is_gpu_available()
>> WRN Found non-empty CUDA_VISIBLE_DEVICES. But PARL has found that Paddle was not complied with CUDA, which may cause issues.
>> True
```