### PR TITLE
fix error with cpu version paddle in GPU machince

### DIFF
--- a/parl/utils/machine_info.py
+++ b/parl/utils/machine_info.py
@@ -101,8 +101,10 @@ def is_gpu_available():
         from paddle import fluid
         if ret is True and not fluid.is_compiled_with_cuda():
             logger.warning("Found non-empty CUDA_VISIBLE_DEVICES. \
-                But PARL found that Paddle was not complied with CUDA, which may cause issues."
+                But PARL found that Paddle was not complied with CUDA, which may cause issues. \
+                Thus PARL will not use GPU."
                            )
+            return False
     return ret
 
 

--- a/parl/utils/machine_info.py
+++ b/parl/utils/machine_info.py
@@ -102,8 +102,7 @@ def is_gpu_available():
         if ret is True and not fluid.is_compiled_with_cuda():
             logger.warning("Found non-empty CUDA_VISIBLE_DEVICES. \
                 But PARL found that Paddle was not complied with CUDA, which may cause issues. \
-                Thus PARL will not use GPU."
-                           )
+                Thus PARL will not use GPU.")
             return False
     return ret
 


### PR DESCRIPTION
```
    ret = get_gpu_count() > 0
    if _HAS_FLUID:
        from paddle import fluid
        if ret is True and not fluid.is_compiled_with_cuda():
            logger.warning("Found non-empty CUDA_VISIBLE_DEVICES. \
                But PARL found that Paddle was not complied with CUDA, which may cause issues."
                           )
    return ret
```
In machine with CUDA GPU enabled, but cpu version paddle installed. Here when cpu version paddle is detected, it will still return ret > 0. Therefore, the following error will raise:

> [06-16 14:16:01 MainThread @logger.py:224] Argv: PARL/examples/QuickStart/train.py
> [06-16 14:16:01 MainThread @machine_info.py:86] nvidia-smi -L found gpu count: 4
> [06-16 14:16:01 MainThread @machine_info.py:105] WRN Found non-empty CUDA_VISIBLE_DEVICES.                 But PARL found that Paddle was not complied with CUDA, which may cause issues.
> [06-16 14:16:01 MainThread @machine_info.py:86] nvidia-smi -L found gpu count: 4
> [06-16 14:16:01 MainThread @machine_info.py:105] WRN Found non-empty CUDA_VISIBLE_DEVICES.                 But PARL found that Paddle was not complied with CUDA, which may cause issues.
> E0616 14:16:01.705137  1281 pybind.cc:1277] Cannot use GPU because you have installed CPU version PaddlePaddle.
> If you want to use GPU, please try to install GPU version PaddlePaddle by: pip install paddlepaddle-gpu
> If you only have CPU, please change CUDAPlace(0) to be CPUPlace().

As a workaround, when cpu version paddlepaddle is detected, the function "is_gpu_available" should return False.