### PR TITLE
Avoid SyntaxWarning on Python >= 3.8

### DIFF
--- a/benchmark/torch/dqn/train.py
+++ b/benchmark/torch/dqn/train.py
@@ -121,7 +121,7 @@ def main():
     model = AtariModel(CONTEXT_LEN, act_dim, args.algo)
     if args.algo in ['DQN', 'Dueling']:
         algorithm = DQN(model, gamma=GAMMA, lr=args.lr)
-    elif args.algo is 'Double':
+    elif args.algo == 'Double':
         algorithm = DDQN(model, gamma=GAMMA, lr=args.lr)
     agent = AtariAgent(algorithm, act_dim=act_dim)
 


### PR DESCRIPTION
% `python3.8`
```
>>> 0 is 0
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
>>> 'Double' is 'Double'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```