### PR TITLE
Travis CI: Discover undefined names in Python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
+os: linux
+dist: focal
 language: python
-sudo: required
-dist: trusty
 services:
   - docker
-os:
-  - linux
 env:
   - JOB=check_style
+install: pip install flake8
 script:
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - docker run -it -v $PWD:/work -w /work paddlepaddle/paddle:latest-dev ./.teamcity/build.sh ${JOB}
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - JOB=check_style
 install: pip install flake8
 script:
-  - flake8 . --count --select=E722,E9,F63,F7,F82 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - docker run -it -v $PWD:/work -w /work paddlepaddle/paddle:latest-dev ./.teamcity/build.sh ${JOB}
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - JOB=check_style
 install: pip install flake8
 script:
-  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  - flake8 . --count --select=E722,E9,F63,F7,F82 --show-source --statistics
   - docker run -it -v $PWD:/work -w /work paddlepaddle/paddle:latest-dev ./.teamcity/build.sh ${JOB}
 notifications:
   email:

--- a/benchmark/torch/AlphaZero/submission_template.py
+++ b/benchmark/torch/AlphaZero/submission_template.py
@@ -538,7 +538,7 @@ game = Connect4Game()
 
 # AlphaZero players
 agent = SimpleAgent(game)
-buffer = io.BytesIO(decoded)
+buffer = io.BytesIO(decoded)  # noqa: F821 'decoded' added in gen_submission.py
 agent.load_checkpoint(buffer)
 mcts_args = dotdict({'numMCTSSims': 800, 'cpuct': 1.0})
 mcts = MCTS(game, agent, mcts_args)


### PR DESCRIPTION
~Blocked by #304 and #305~

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.