### PR TITLE
Explicit is better than implicit... ImportError

### DIFF
--- a/parl/utils/summary.py
+++ b/parl/utils/summary.py
@@ -14,5 +14,5 @@
 
 try:
     from parl.utils.visualdl import *
-except:
+except ImportError:
     from parl.utils.tensorboard import *


### PR DESCRIPTION
Helps humans and linters understand what is expected.