### PR TITLE
fix auto set dir

### DIFF
--- a/parl/utils/logger.py
+++ b/parl/utils/logger.py
@@ -170,7 +170,10 @@ def auto_set_dir(action=None):
         dirname(str): log directory used in the global logging directory.
     """
     mod = sys.modules['__main__']
-    basename = os.path.basename(mod.__file__)
+    if hasattr(mod, '__file__'):
+        basename = os.path.basename(mod.__file__)
+    else:
+        basename = ''
     dirname = os.path.join('train_log', basename[:basename.rfind('.')])
     dirname = os.path.normpath(dirname)
 


### PR DESCRIPTION
When directly calling methods of `summary` in Python interpreter or Jupyter notebook, following error raises:
![图片](https://user-images.githubusercontent.com/25984272/88154167-fb070e80-cc38-11ea-8176-7eb500246843.png)
<img width="699" alt="图片" src="https://user-images.githubusercontent.com/25984272/88154200-05290d00-cc39-11ea-8eb8-e4031ac39216.png">

