### PR TITLE
support logger printing in web job log

### DIFF
--- a/parl/remote/utils.py
+++ b/parl/remote/utils.py
@@ -102,7 +102,7 @@ def redirect_stdout_to_file(file_path):
     f = open(file_path, 'a')
     sys.stdout = f
 
-    # NOTE: we should add the handler after executing above code.
+    # NOTE: we should add the handler after executing the above code.
     handler = logger.add_stdout_handler()
 
     try:

--- a/parl/remote/utils.py
+++ b/parl/remote/utils.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import sys
 from contextlib import contextmanager
 import os
 from parl.utils import isnotebook, logger
-from parl.utils.logger import _Formatter
 
 __all__ = [
     'load_remote_class', 'redirect_stdout_to_file', 'locate_remote_file',

--- a/parl/remote/utils.py
+++ b/parl/remote/utils.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import logging
 import sys
 from contextlib import contextmanager
 import os
-from parl.utils import isnotebook
+from parl.utils import isnotebook, logger
+from parl.utils.logger import _Formatter
 
 __all__ = [
     'load_remote_class', 'redirect_stdout_to_file', 'locate_remote_file',
@@ -96,14 +99,20 @@ def redirect_stdout_to_file(file_path):
     >>> print('test')
     test
     """
+
     tmp = sys.stdout
     f = open(file_path, 'a')
     sys.stdout = f
+
+    # NOTE: we should add the handler after executing above code.
+    handler = logger.add_stdout_handler()
+
     try:
         yield
     finally:
         sys.stdout = tmp
         f.close()
+        logger.remove_handler(handler)
 
 
 def locate_remote_file(module_path):

--- a/parl/utils/logger.py
+++ b/parl/utils/logger.py
@@ -21,7 +21,10 @@ from termcolor import colored
 import shutil
 from datetime import datetime
 
-__all__ = ['set_dir', 'get_dir', 'set_level', 'auto_set_dir']
+__all__ = [
+    'set_dir', 'get_dir', 'set_level', 'auto_set_dir', 'add_stdout_handler',
+    'remove_handler'
+]
 
 # globals: logger file and directory:
 LOG_DIR = None
@@ -218,6 +221,19 @@ Press any other key to exit. """)
 
 def get_dir():
     return LOG_DIR
+
+
+def add_stdout_handler():
+    global _logger
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(_Formatter(datefmt='%m-%d %H:%M:%S'))
+    _logger.addHandler(handler)
+    return handler
+
+
+def remove_handler(handler):
+    global _logger
+    _logger.removeHandler(handler)
 
 
 # Will save log to log_dir/main_file_name/log.log by default


### PR DESCRIPTION
```python
import parl
from parl.utils import logger

parl.connect("localhost:8010")

@parl.remote_class
class Actor(object):
    def __init__(self):
        print("1. print output")
        logger.info("2. logger info")
        print("3. print output")
        logger.warning("4. logger warning")
        print("5. print output")
        logger.error("6. logger error")

actor = Actor()
```
The job log showed on the web after executing the above code:
![image](https://user-images.githubusercontent.com/5762635/99614516-9d52c980-2a54-11eb-85d3-52e0560865ee.png)

