### PR TITLE
redirect stderr of subprocesses to console output

### DIFF
--- a/parl/remote/job.py
+++ b/parl/remote/job.py
@@ -37,7 +37,7 @@ from parl.remote import remote_constants
 from parl.utils.exceptions import SerializeError, DeserializeError
 from parl.remote.message import InitializedJob
 from parl.remote.utils import load_remote_class, redirect_stdout_to_file
-from parl.remote.zmp_utils import create_client_socket
+from parl.remote.zmq_utils import create_client_socket
 
 
 class Job(object):

--- a/parl/remote/job.py
+++ b/parl/remote/job.py
@@ -30,13 +30,14 @@ import time
 import traceback
 import zmq
 from multiprocessing import Process, Pipe
-from parl.utils import to_str, to_byte, get_ip_address, logger, kill_process
+from parl.utils import to_str, to_byte, get_ip_address, logger
 from parl.remote.communication import loads_argument, loads_return,\
     dumps_argument, dumps_return
 from parl.remote import remote_constants
 from parl.utils.exceptions import SerializeError, DeserializeError
 from parl.remote.message import InitializedJob
 from parl.remote.utils import load_remote_class, redirect_stdout_to_file
+from parl.remote.zmp_utils import create_client_socket
 
 
 class Job(object):
@@ -106,8 +107,8 @@ class Job(object):
 
         self.ctx = zmq.Context()
         # create the job_socket
-        self.job_socket = self.ctx.socket(zmq.REQ)
-        self.job_socket.connect("tcp://{}".format(self.worker_address))
+        self.job_socket = create_client_socket(
+            self.ctx, self.worker_address, heartbeat_timeout=True)
 
         # a thread that reply ping signals from the client
         ping_heartbeat_socket, ping_heartbeat_address = self._create_heartbeat_server(
@@ -138,10 +139,19 @@ class Job(object):
             self.job_address, worker_heartbeat_address,
             client_heartbeat_address, ping_heartbeat_address, None, self.pid,
             self.job_id, self.log_server_address)
-        self.job_socket.send_multipart(
-            [remote_constants.NORMAL_TAG,
-             cloudpickle.dumps(initialized_job)])
-        message = self.job_socket.recv_multipart()
+
+        try:
+            self.job_socket.send_multipart([
+                remote_constants.NORMAL_TAG,
+                cloudpickle.dumps(initialized_job)
+            ])
+            message = self.job_socket.recv_multipart()
+        except zmq.error.Again as e:
+            logger.warning("[Job] Cannot connect to the worker{}. ".format(
+                self.worker_address) + "Job will quit.")
+            self.job_socket.close(0)
+            os._exit(0)
+
         worker_thread.start()
 
         tag = message[0]
@@ -237,8 +247,7 @@ class Job(object):
                     self.worker_address) + "Job will quit.")
                 break
         socket.close(0)
-        # `os._exit(1)` cannot exit completely, so we use the following killing way.
-        kill_process('remote/job.py.*{}'.format(self.worker_address))
+        os._exit(1)
 
     def wait_for_files(self, reply_socket, job_address):
         """Wait for python files from remote object.

--- a/parl/remote/job.py
+++ b/parl/remote/job.py
@@ -30,7 +30,7 @@ import time
 import traceback
 import zmq
 from multiprocessing import Process, Pipe
-from parl.utils import to_str, to_byte, get_ip_address, logger
+from parl.utils import to_str, to_byte, get_ip_address, logger, kill_process
 from parl.remote.communication import loads_argument, loads_return,\
     dumps_argument, dumps_return
 from parl.remote import remote_constants
@@ -237,7 +237,8 @@ class Job(object):
                     self.worker_address) + "Job will quit.")
                 break
         socket.close(0)
-        os._exit(1)
+        # `os._exit(1)` cannot exit completely, so we use the following killing way.
+        kill_process('remote/job.py.*{}'.format(self.worker_address))
 
     def wait_for_files(self, reply_socket, job_address):
         """Wait for python files from remote object.

--- a/parl/remote/worker.py
+++ b/parl/remote/worker.py
@@ -235,11 +235,7 @@ class Worker(object):
         # Redirect the output to DEVNULL
         FNULL = open(os.devnull, 'w')
         for _ in range(job_num):
-            subprocess.Popen(
-                command,
-                stdout=FNULL,
-                stderr=subprocess.STDOUT,
-                close_fds=True)
+            subprocess.Popen(command, stdout=FNULL, close_fds=True)
         FNULL.close()
 
         new_jobs = []
@@ -422,7 +418,7 @@ class Worker(object):
         else:
             FNULL = open(os.devnull, 'w')
         log_server_proc = subprocess.Popen(
-            command, stdout=FNULL, stderr=subprocess.STDOUT, close_fds=True)
+            command, stdout=FNULL, close_fds=True)
         FNULL.close()
 
         log_server_address = "{}:{}".format(self.worker_ip, port)

--- a/parl/utils/logger.py
+++ b/parl/utils/logger.py
@@ -91,10 +91,9 @@ def _getlogger():
         logger.addHandler(handler)
         return logger
 
-    if 'XPARL' not in os.environ:
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(_Formatter(datefmt='%m-%d %H:%M:%S'))
-        logger.addHandler(handler)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(_Formatter(datefmt='%m-%d %H:%M:%S'))
+    logger.addHandler(handler)
     return logger
 
 


### PR DESCRIPTION
After this PR, the stderr of subprocesses(starting the master/worker/job) will be redirected to the console output.

For example:
![image](https://user-images.githubusercontent.com/5762635/100958499-681ba080-3557-11eb-85c4-dbf0f28c37cc.png)
