### PR TITLE
assign with new_weights

### DIFF
--- a/parl/core/torch/model.py
+++ b/parl/core/torch/model.py
@@ -128,6 +128,7 @@ class Model(nn.Module, ModelBase):
         Args:
             weights (dict): a Python dict containing the parameters.
         """
+        new_weights = dict()
         for key in weights.keys():
-            weights[key] = torch.from_numpy(weights[key])
-        self.load_state_dict(weights)
+            new_weights[key] = torch.from_numpy(weights[key])
+        self.load_state_dict(new_weights)


### PR DESCRIPTION
The function `set_weights` modifies the type of weights by converting it into tensor from np.array.
It leads to an error if we want to assign the weights into several agents.

```python
def sync_agents(agents):
  agent_num = len(agents)
  weights = agents[-1].get_weights()
  for i in range(agent_num - 1):
    agents[i].set_weights(weights) << it will lead to the error since the value of weights is expected to be a np.array
```