### PR TITLE
fix passing wrong argument names in @parl.remote_class

### DIFF
--- a/parl/remote/remote_decorator.py
+++ b/parl/remote/remote_decorator.py
@@ -89,6 +89,11 @@ def remote_class(*args, **kwargs):
         proxy_wrapper._original = cls
         return proxy_wrapper
 
+    args_names = ['max_memory', 'wait']
+    for key in kwargs:
+        assert key in args_names, "Argument `{}` is not supported in the `@parl.remote_class`, supported arguments: {}".format(
+            key, args_names)
+
     max_memory = kwargs.get('max_memory')
     wait = kwargs.get('wait', True)
     """

--- a/parl/remote/tests/remote_class_test.py
+++ b/parl/remote/tests/remote_class_test.py
@@ -83,6 +83,14 @@ class TestCluster(unittest.TestCase):
         master.exit()
         worker1.exit()
 
+    def test_passing_arguments_with_unsupported_argument_names(self):
+        with self.assertRaises(AssertionError):
+
+            @parl.remote_class(xxx=10)
+            class Actor2(object):
+                def __init__(self):
+                    pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fix #603 