### PR TITLE
remove dependency on visualDL by default due to the compilation error on readthe docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
         "requests",
         "grpcio>=1.27.2",
         "protobuf>=3.14.0",
-        "visualdl>=2.0.0b;python_version>='3.8' and platform_system=='Linux'",
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
see https://readthedocs.org/projects/parl/builds/16921179/ for more information.