### PR TITLE
release v2.1.1

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -4,7 +4,7 @@
 
 [English](./README.md) | 简体中文
 
-[![Documentation Status](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://parl.readthedocs.io/en/latest/index.html) [![Documentation Status](https://img.shields.io/badge/中文文档-最新-brightgreen.svg)](https://parl.readthedocs.io/zh_CN/latest/) [![Documentation Status](https://img.shields.io/badge/手册-中文-brightgreen.svg)](./docs/zh_CN/Overview.md) [![Release](https://img.shields.io/badge/release-v2.1-blue.svg)](https://github.com/PaddlePaddle/PARL/releases)
+[![Documentation Status](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://parl.readthedocs.io/en/latest/index.html) [![Documentation Status](https://img.shields.io/badge/中文文档-最新-brightgreen.svg)](https://parl.readthedocs.io/zh_CN/latest/) [![Documentation Status](https://img.shields.io/badge/手册-中文-brightgreen.svg)](./docs/zh_CN/Overview.md) [![Release](https://img.shields.io/badge/release-v2.1.1-blue.svg)](https://github.com/PaddlePaddle/PARL/releases)
 
 
 > PARL 是一个高性能、灵活的强化学习框架。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 English | [简体中文](./README.cn.md)
 
-[![Documentation Status](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://parl.readthedocs.io/en/latest/index.html) [![Documentation Status](https://img.shields.io/badge/中文文档-最新-brightgreen.svg)](https://parl.readthedocs.io/zh_CN/latest/) [![Documentation Status](https://img.shields.io/badge/手册-中文-brightgreen.svg)](./docs/zh_CN/Overview.md) [![Release](https://img.shields.io/badge/release-v2.1-blue.svg)](https://github.com/PaddlePaddle/PARL/releases)
+[![Documentation Status](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://parl.readthedocs.io/en/latest/index.html) [![Documentation Status](https://img.shields.io/badge/中文文档-最新-brightgreen.svg)](https://parl.readthedocs.io/zh_CN/latest/) [![Documentation Status](https://img.shields.io/badge/手册-中文-brightgreen.svg)](./docs/zh_CN/Overview.md) [![Release](https://img.shields.io/badge/release-v2.1.1-blue.svg)](https://github.com/PaddlePaddle/PARL/releases)
 
 > PARL is a flexible and high-efficient reinforcement learning framework.
 

--- a/parl/__init__.py
+++ b/parl/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.1"
+__version__ = "2.1.1"
 """
 generates new PARL python API
 """


### PR DESCRIPTION
## Release Notes
This is a very minor bug fix release for 2.1

### Bug Fixes
- https://github.com/PaddlePaddle/PARL/pull/1009#issue-1464041001 - Previously `cv2` was a necessary module even if only `atari_wrappers` used it. This has been fixed to allow users not to install `cv2` while using PARL.