### PR TITLE
fix bug of uninitialized variables

### DIFF
--- a/parl/remote/cluster_monitor.py
+++ b/parl/remote/cluster_monitor.py
@@ -33,18 +33,21 @@ class ClusterMonitor(object):
         }
         self.lock = threading.Lock()
 
-    def add_worker_status(self, worker_address, hostname):
+    def add_worker_status(self, worker_address, hostname, total_cpus):
         """Record worker status when it is connected to the cluster.
         
         Args:
             worker_address (str): worker ip address
             hostname (str): worker hostname 
+            total_cpus(int): the number of CPU in the worker
         """
         self.lock.acquire()
         worker_status = self.status['workers'][worker_address]
         worker_status['load_value'] = deque(maxlen=10)
         worker_status['load_time'] = deque(maxlen=10)
         worker_status['hostname'] = hostname
+        worker_status['vacant_cpus'] = total_cpus
+        worker_status['used_cpus'] = 0
         self.lock.release()
 
     def add_client_job(self, client_id, job_info):
@@ -72,7 +75,7 @@ class ClusterMonitor(object):
             update_status (dict): worker updated status information 
                                 (vacant_memory, used_memory, load_time, load_value).
             worker_address (str): worker ip address.
-            vacant_cpus (int): vacant cpu number.
+            vacant_cpus (int): the number of available CPUs.
             total_cpus (int): total cpu number.
         """
         self.lock.acquire()

--- a/parl/remote/master.py
+++ b/parl/remote/master.py
@@ -126,7 +126,8 @@ class Master(object):
             worker_address = initialized_worker.worker_address
             self.job_center.add_worker(initialized_worker)
             hostname = self.job_center.get_hostname(worker_address)
-            self.cluster_monitor.add_worker_status(worker_address, hostname)
+            total_cpus = self.job_center.get_total_cpu(worker_address)
+            self.cluster_monitor.add_worker_status(worker_address, hostname, total_cpus)
             logger.info("A new worker {} is added, ".format(worker_address) +
                         "the cluster has {} CPUs.\n".format(self.cpu_num))
 


### PR DESCRIPTION
The cluster_monitor does not initialize the CPU information for the worker, until the worker update its information for the first time.
The may cause bug when the user check the cluster information by calling `xparl status`:

<img width="841" alt="564082e09f0ca0102654a65a1862d51a" src="https://user-images.githubusercontent.com/25046619/218066413-404b8b4e-e513-4867-92a1-a7880df3d7cf.png">
