### PR TITLE
fix core dump on aarch64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "psutil>=5.6.2",
         "flask_cors",
         "requests",
-        "grpcio==1.37.0",
+        "grpcio==1.38.1",
         "protobuf>=3.14.0, <=3.20.0",
         "pynvml"
     ],


### PR DESCRIPTION
parl在aarch64平台python3.9版本下训练模型时会出现`free(): invalid pointer`的错误继而发生core dump，原因在于parl安装的依赖1.37.0版本的grpcio在aarch64架构下会发生core dump。[参考链接](https://github.com/grpc/grpc/issues/26279) 
此问题已在grpcio 1.38.1版本修复，故修改setup.py中依赖的grpcio版本以解决该bug。